### PR TITLE
GCP - gpuType default to "" instead of None

### DIFF
--- a/src/terraformFunctions.py
+++ b/src/terraformFunctions.py
@@ -264,7 +264,7 @@ def terraformProvisionment(
 
             terraform_cli_vars["gpuType"] = tryTakeFromYaml(configs,
                                                             "gpuType",
-                                                            None)
+                                                            "")
 
         if configs["providerName"] in ("aws", "google",
                             "openstack", "opentelekomcloud", "exoscale"):


### PR DESCRIPTION
If gpuType is set to None (Terraform's null) the provisioning fail. This fixes that, by setting the default to the empty string instead of None.