### PR TITLE
Add noTerraform support for proGAN

### DIFF
--- a/src/schemas/configs_sch_noTerraform.yaml
+++ b/src/schemas/configs_sch_noTerraform.yaml
@@ -29,6 +29,10 @@ properties:
                 type: array
                 items:
                   type: string
+            proGANTest:
+                type: array
+                items:
+                  type: string
     dockerCE:
         type: string
     dockerEngine:


### PR DESCRIPTION
Add schema support to allow the proGAN
test and cluster to work with the -noTerraform
flag.