### PR TITLE
Fix literal error with is 0 check

### DIFF
--- a/src/terraformFunctions.py
+++ b/src/terraformFunctions.py
@@ -85,7 +85,7 @@ def destroyTF(baseCWD, clusters=None):
         mainTfDir = "src/tests/%s" % cluster
         cmd = "terraform destroy -auto-approve"
         exitCode = runTerraform(toLog, cmd, mainTfDir, baseCWD, cluster, msg)
-        if exitCode is 0:
+        if exitCode == 0:
             if keepTFfiles is not True:
                 cleanupTF("src/tests/%s/" % cluster)
             else:


### PR DESCRIPTION
Fix a python warning/error that arises
from using the "is" keyword with a literal.

Fixes: #3